### PR TITLE
Fix sodium crypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-crypto"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["sean billig <sean.billig@gmail.com>"]
 edition = "2018"
 license = "LGPL-3.0"

--- a/src/dalek/secretbox.rs
+++ b/src/dalek/secretbox.rs
@@ -12,7 +12,7 @@ pub fn open(k: &Key, mut c: &mut [u8], hmac: &Hmac, n: &Nonce) -> bool {
     let cipher = XSalsa20Poly1305::new(key);
 
     cipher
-        .decrypt_in_place_detached(nonce, &[], &mut c, &tag)
+        .decrypt_in_place_detached(nonce, &[], &mut c, tag)
         .is_ok()
 }
 

--- a/src/dalek/sign.rs
+++ b/src/dalek/sign.rs
@@ -34,7 +34,7 @@ where
 }
 
 pub fn keypair_from_seed(seed: &[u8]) -> Option<Keypair> {
-    let s = dalek::SecretKey::from_bytes(&seed).ok()?;
+    let s = dalek::SecretKey::from_bytes(seed).ok()?;
     let p = dalek::PublicKey::from(&s);
 
     Some(Keypair {

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -111,7 +111,7 @@ impl Keypair {
     /// Generate a signature for a given byte slice.
     #[cfg(any(feature = "sodium", feature = "dalek"))]
     pub fn sign(&self, b: &[u8]) -> Signature {
-        sign::sign(&self, b)
+        sign::sign(self, b)
     }
 }
 

--- a/src/sodium/sign.rs
+++ b/src/sodium/sign.rs
@@ -37,9 +37,9 @@ pub fn keypair_from_seed(seed: &[u8]) -> Option<Keypair> {
 
 pub fn sign(k: &Keypair, b: &[u8]) -> Signature {
     let s = sign::sign_detached(b, &k.into());
-    Signature(s.0)
+    Signature(s.to_bytes())
 }
 
 pub fn verify(k: &PublicKey, sig: &Signature, b: &[u8]) -> bool {
-    sign::verify_detached(&sign::Signature(sig.0), b, &sign::PublicKey(k.0))
+    sign::verify_detached(&sign::Signature::new(sig.0), b, &sign::PublicKey(k.0))
 }


### PR DESCRIPTION
This PR started as a simple version bump to allow the latest version (with LGPL-3.0 license) to be published to crates.io.

`0.2.2` -> `0.2.3`

Then the CI uncovered two small bugs in the sodium crypto code. @sbillig, could you please take a look and ensure I'm not breaking things here?

The third commit makes tiny changes to satisfy clippy (removing three needless borrows).